### PR TITLE
Force single Exporter instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ruleset(name="process_stats") {
     type="omprog"
     name="to_exporter"
     binary="/usr/local/bin/rsyslog_exporter [--tls.server-crt=/path/to/tls.crt --tls.server-key=/path/to/tls.key]"
+    forceSingleInstance="on"
   )
 }
 ```


### PR DESCRIPTION
After scaling our rsyslog deployment we started seeing these error messages:

```
rsyslog_exporter[3976481]: 2024/11/05 10:49:28 Listening on :9404
rsyslog_exporter[3976481]: 2024/11/05 10:49:28 listen tcp :9404: bind: address already in use
rsyslogd[3791026]: action 'to_exporter' resumed (module 'omprog') [v8.2408.0 try https://www.rsyslog.com/e/2359 ]
rsyslogd[3791026]: child process (pid 3976481) exited with status 1 [v8.2408.0]
rsyslogd[3791026]: omprog: program '/usr/bin/rsyslog_exporter' (pid 3976481) terminated; will be restarted [v8.2408.0 try https://www.rsyslog.com/e/2119 ]
rsyslogd[3791026]: action 'to_exporter' suspended (module 'omprog'), retry 0. There should be messages before this one giving the reason for suspension. [v8.2408.0 try https://www.rsyslog.com/e/2007 ]
```

Obviously rsyslog is trying to spawn multiple instances of the exporter, [omprog's documentation](https://www.rsyslog.com/doc/configuration/modules/omprog.html#forcesingleinstance) backs this up:

> By default, the omprog action will start an instance (process) of the external program per worker thread (the maximum number of worker threads can be specified with the [queue.workerThreads](https://www.rsyslog.com/doc/rainerscript/queue_parameters.html) parameter). 

We do run the suggested config from the exporter readme so we don't have multiple workers configured for impstats per se, we do have multiple input/queue workers though so my guess is this propagates to impstats somehow.

TLDR: the additional omprog parameter prohibits it from trying to launch one exporter per worker thread, which fixes the error messages above. 